### PR TITLE
Remove plyr dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ Imports:
     dplyr,
     ggplot2,
     httr,
-    plyr,
     rgdal,
     stringr,
     xml2,

--- a/R/import_data.R
+++ b/R/import_data.R
@@ -51,7 +51,7 @@ import_data_delim <- function(path_data) {
         }
   }
 
-  if (plyr::empty(data)) {
+  if (nrow(data) == 0) {
        data <- data.table::fread(path_data)
   }
 


### PR DESCRIPTION
The plyr package is deprecated and we can easily replace it since it is used just once and for a simple task