### PR TITLE
Add GitHub links to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,5 +48,5 @@ Config/Needs/website:
     epiverse-trace/epiversetheme
 VignetteBuilder: knitr
 Language: spa
-URL: https://github.com/epiverse-trace/sivirep
+URL: https://epiverse-trace.github.io/sivirep, https://github.com/epiverse-trace/sivirep
 BugReports: https://github.com/epiverse-trace/sivirep/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,3 +48,5 @@ Config/Needs/website:
     epiverse-trace/epiversetheme
 VignetteBuilder: knitr
 Language: spa
+URL: https://github.com/epiverse-trace/sivirep
+BugReports: https://github.com/epiverse-trace/sivirep/issues


### PR DESCRIPTION
It may make sense to also merge this directly to main to update the website as soon as possible but I'll leave this choice up to you.