### PR TITLE
fix(impor_data_event): adding extra validation for dengue 2016

### DIFF
--- a/R/import_data.R
+++ b/R/import_data.R
@@ -170,16 +170,18 @@ import_data_event <- function(nombre_event,
       data_import <- limpiar_encabezado(data_import)
       data_import$fec_def <- as.character(data_import$fec_def)
       nombre_cols <- names(data_import)
-      nombre_cols <- nombre_cols[-which(nombre_cols %in% cols_remover)]
       index_cols_eve <- which(stringr::str_detect(nombre_cols,
                                                   stringr::fixed("cod_eve_"))
                               %in% TRUE)
       if (!identical(index_cols_eve,
                      integer(0))) {
-        names(data_import)[index_cols_eve[1]] <- "cod_eve"
-        nombre_cols[index_cols_eve[1]] <- "cod_eve"
-        nombre_cols <- nombre_cols[-(2:length(index_cols_eve))]
+          names(data_import)[index_cols_eve[1]] <- "cod_eve"
+          index_cols_eve[1] <- index_cols_eve[-1]
+          data_import <-
+            data_import[, -index_cols_eve]
+          nombre_cols <- names(data_import)
       }
+      nombre_cols <- nombre_cols[-which(nombre_cols %in% cols_remover)]
       data_event <- rbind(data_event, data_import[, nombre_cols])
     }
   }

--- a/R/import_data.R
+++ b/R/import_data.R
@@ -171,6 +171,15 @@ import_data_event <- function(nombre_event,
       data_import$fec_def <- as.character(data_import$fec_def)
       nombre_cols <- names(data_import)
       nombre_cols <- nombre_cols[-which(nombre_cols %in% cols_remover)]
+      index_cols_eve <- which(stringr::str_detect(nombre_cols,
+                                                  stringr::fixed("cod_eve_"))
+                              %in% TRUE)
+      if (!identical(index_cols_eve,
+                     integer(0))) {
+        names(data_import)[index_cols_eve[1]] <- "cod_eve"
+        nombre_cols[index_cols_eve[1]] <- "cod_eve"
+        nombre_cols <- nombre_cols[-(2:length(index_cols_eve))]
+      }
       data_event <- rbind(data_event, data_import[, nombre_cols])
     }
   }
@@ -214,7 +223,8 @@ import_sep_data <- function(path_data = NULL, cache = TRUE) {
       }
     }
     if (stringr::str_detect(file_name, ".xls")) {
-      data <- readxl::read_excel(file_path)
+      data <- readxl::read_excel(file_path,
+                                 col_types = "text")
     }
   }
   return(data)

--- a/man/sivirep-package.Rd
+++ b/man/sivirep-package.Rd
@@ -19,13 +19,13 @@ Authors:
 Other contributors:
 \itemize{
   \item Hugo Gruson \email{hugo.gruson+R@normalesup.org} (\href{https://orcid.org/0000-0002-4094-1476}{ORCID}) [contributor]
-  \item Laura GC3mez Bermeo \email{gomezblaura@javeriana.edu.co} (\href{https://orcid.org/0000-0003-4028-2893}{ORCID}) [contributor]
-  \item AndrC)s Moreno \email{ad.morenob@javeriana.edu.co} (\href{https://orcid.org/0000-0001-9266-731X}{ORCID}) [contributor]
-  \item Miguel GC!mez [contributor]
-  \item Jennifer MC)ndez-Romero [contributor]
-  \item Johan CalderC3n [contributor]
-  \item Lady FlC3rez-Tapiero [contributor]
-  \item VerC3nica Tangarife-Arredondo [contributor]
+  \item Laura Gómez Bermeo \email{gomezblaura@javeriana.edu.co} (\href{https://orcid.org/0000-0003-4028-2893}{ORCID}) [contributor]
+  \item Andrés Moreno \email{ad.morenob@javeriana.edu.co} (\href{https://orcid.org/0000-0001-9266-731X}{ORCID}) [contributor]
+  \item Miguel Gámez [contributor]
+  \item Jennifer Méndez-Romero [contributor]
+  \item Johan Calderón [contributor]
+  \item Lady Flórez-Tapiero [contributor]
+  \item Verónica Tangarife-Arredondo [contributor]
 }
 
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] I have read the CONTRIBUTING guidelines 
- [ ] A new item has been added to `NEWS.md`
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
`import_data_function` updated

* **What is the current behavior?** (You can also link to an open issue here)
The cod_eve column in the data that provides SIVIGILA appears duplicated in Dengue 2016. Related issue #90

* **What is the new behavior (if this is a feature change)?**
Created extra validation for cod_eve column in the data of Dengue 2016

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, it does.

* **Other information**:
The only year for Dengue with this problem is 2016.

Refs: #90 