### PR TITLE
fix: the percent parameter in agrupar_edad_sex

### DIFF
--- a/R/checking_data.R
+++ b/R/checking_data.R
@@ -460,8 +460,8 @@ agrupar_sex_semanaepi <- function(data_event,
 #' @export
 agrupar_edad <- function(data_event,
                          nomb_col = "edad",
-                         porcentaje = FALSE,
-                         interval_edad = 10) {
+                         interval_edad = 10,
+                         porcentaje = FALSE) {
   stopifnot("El parametro data_event es obligatorio" = !missing(data_event),
             "El parametro data_event debe ser un data.frame" =
               is.data.frame(data_event),
@@ -472,15 +472,15 @@ agrupar_edad <- function(data_event,
             "El parametro interval_edad debe ser un numero"
             = is.numeric(interval_edad))
   data_event_edad <- agrupar_cols_casos(data_event,
-                                        nomb_col,
-                                        porcentaje)
+                                        nomb_col)
   data_event_edad <-
     agrupar_rango_edad_casos(data_event_edad,
                              nomb_col,
                              min_val = 0,
                              max_val =
                              max(data_event_edad[[nomb_col]]),
-                             paso = interval_edad)
+                             paso = interval_edad,
+                             porcentaje = porcentaje)
   return(data_event_edad)
 }
 

--- a/R/checking_data.R
+++ b/R/checking_data.R
@@ -532,7 +532,8 @@ agrupar_edad_sex <- function(data_event,
     min_val = 0,
     max_val =
       max(data_event_edad_sex[[nomb_cols[1]]]),
-    paso = interval_edad
+    paso = interval_edad,
+    porcentaje = porcentaje
   )
   return(data_event_edad_sex)
 }

--- a/R/checking_data.R
+++ b/R/checking_data.R
@@ -225,6 +225,9 @@ agrupar_cols_casos <- function(data_event,
 #' de las edades
 #' @param paso Un `numeric` (numerico) que contiene el valor del paso
 #' para generar el rango de edades
+#' @param porcentaje Un `boolean` (TRUE o FALSE) que indica si
+#' se debe agregar el porcentaje de casos como columna; su valor
+#' por defecto es `TRUE`
 #' @return Un `data.frame` con los datos de la enfermedad o evento
 #' agrupados por el rango de edad y número de casos
 #' @examples
@@ -237,14 +240,16 @@ agrupar_cols_casos <- function(data_event,
 #'                          nomb_col = "edad",
 #'                          min_val = 0,
 #'                          max_val = max(data_edad$edad),
-#'                          paso = 10)
+#'                          paso = 10,
+#'                          porcentaje = TRUE)
 #' @export
 agrupar_rango_edad_casos <- function(data_event,
                                      nomb_col,
                                      col_adicional = NULL,
                                      min_val,
                                      max_val,
-                                     paso) {
+                                     paso,
+                                     porcentaje = TRUE) {
   stopifnot("El parametro data_event es obligatorio" = !missing(data_event),
             "El parametro data_event debe ser un data.frame" =
               is.data.frame(data_event),
@@ -256,14 +261,20 @@ agrupar_rango_edad_casos <- function(data_event,
   }
   stopifnot("El parametro nomb_col debe ser una cadena de caracteres"
             = is.character(nomb_col))
+  total_casos <- sum(data_event$casos)
   data_vals_rango <- data_event %>%
     dplyr::mutate(ranges = cut(
       data_event[[nomb_col]],
       seq(min_val, max_val, paso)
     )) %>%
     dplyr::group_by_at(c("ranges", col_adicional)) %>%
-    dplyr::summarize(casos = sum(.data$casos), .groups = "drop") %>%
+    dplyr::summarize(casos = sum(.data$casos),
+                     .groups = "drop") %>%
     as.data.frame()
+  if (porcentaje) {
+    data_vals_rango <- data_vals_rango %>%
+      mutate(porcentaje =  round(.data$casos / total_casos * 100, 3))
+  }
   names(data_vals_rango)[names(data_vals_rango) == "ranges"] <- nomb_col
   return(data_vals_rango)
 }

--- a/R/checking_data.R
+++ b/R/checking_data.R
@@ -445,8 +445,8 @@ agrupar_sex_semanaepi <- function(data_event,
 #' de la columna de los datos de la enfermedad o evento que contiene las edades;
 #' su valor por defecto es `"edad"`
 #' @param porcentaje Un `boolean` (TRUE o FALSE) que indica si
-#' es necesario agregar un porcentaje de casos como una columna; su valor por
-#' defecto es `FALSE`
+#' se debe agregar el porcentaje de casos como columna; su valor
+#' por defecto es `FALSE`
 #' @param interval_edad Un `numeric` (numerico) que contiene el intervalo del
 #' rango de edades; su valor por defecto es `10`
 #' @return Un `data.frame` con los datos de la enfermedad o evento agrupados

--- a/R/checking_data.R
+++ b/R/checking_data.R
@@ -495,7 +495,7 @@ agrupar_edad <- function(data_event,
 #' la(s) columna(s) de los datos de la enfermedad o evento que contienen
 #' las edades y el sexo; su valor por defecto es `c("edad", "sexo")`
 #' @param porcentaje Un `boolean` (TRUE o FALSE) que indica si
-#' es necesario agregar un porcentaje de casos como una columna; su valor
+#' se debe agregar el porcentaje de casos como columna; su valor
 #' por defecto es `TRUE`
 #' @param interval_edad Un `numeric` (numerico) que contiene el intervalo del
 #' rango de edades; su valor por defeccto es `10`

--- a/man/agrupar_edad.Rd
+++ b/man/agrupar_edad.Rd
@@ -7,8 +7,8 @@
 agrupar_edad(
   data_event,
   nomb_col = "edad",
-  porcentaje = FALSE,
-  interval_edad = 10
+  interval_edad = 10,
+  porcentaje = FALSE
 )
 }
 \arguments{
@@ -19,12 +19,12 @@ o evento}
 de la columna de los datos de la enfermedad o evento que contiene las edades;
 su valor por defecto es `"edad"`}
 
-\item{porcentaje}{Un `boolean` (TRUE o FALSE) que indica si
-es necesario agregar un porcentaje de casos como una columna; su valor por
-defecto es `FALSE`}
-
 \item{interval_edad}{Un `numeric` (numerico) que contiene el intervalo del
 rango de edades; su valor por defecto es `10`}
+
+\item{porcentaje}{Un `boolean` (TRUE o FALSE) que indica si
+se debe agregar el porcentaje de casos como columna; su valor
+por defecto es `FALSE`}
 }
 \value{
 Un `data.frame` con los datos de la enfermedad o evento agrupados

--- a/man/agrupar_edad_sex.Rd
+++ b/man/agrupar_edad_sex.Rd
@@ -21,7 +21,7 @@ la(s) columna(s) de los datos de la enfermedad o evento que contienen
 las edades y el sexo; su valor por defecto es `c("edad", "sexo")`}
 
 \item{porcentaje}{Un `boolean` (TRUE o FALSE) que indica si
-es necesario agregar un porcentaje de casos como una columna; su valor
+se debe agregar el porcentaje de casos como columna; su valor
 por defecto es `TRUE`}
 
 \item{interval_edad}{Un `numeric` (numerico) que contiene el intervalo del

--- a/man/agrupar_rango_edad_casos.Rd
+++ b/man/agrupar_rango_edad_casos.Rd
@@ -10,7 +10,8 @@ agrupar_rango_edad_casos(
   col_adicional = NULL,
   min_val,
   max_val,
-  paso
+  paso,
+  porcentaje = TRUE
 )
 }
 \arguments{
@@ -34,6 +35,10 @@ de las edades}
 
 \item{paso}{Un `numeric` (numerico) que contiene el valor del paso
 para generar el rango de edades}
+
+\item{porcentaje}{Un `boolean` (TRUE o FALSE) que indica si
+se debe agregar el porcentaje de casos como columna; su valor
+por defecto es `TRUE`}
 }
 \value{
 Un `data.frame` con los datos de la enfermedad o evento
@@ -53,5 +58,6 @@ agrupar_rango_edad_casos(data_event = data_edad,
                          nomb_col = "edad",
                          min_val = 0,
                          max_val = max(data_edad$edad),
-                         paso = 10)
+                         paso = 10,
+                         porcentaje = TRUE)
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**

- [x] I have read the CONTRIBUTING guidelines
- [ ] A new item has been added to `NEWS.md`
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Checks have been run locally and pass

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix: The parameter `porcentaje` has been added, calculated and included in the response of the functions: `agrupar_edad`, `agrupar_edad_sex` and `agrupar_rango_edad_casos` . Their documentation and example have been updated.


* **What is the current behavior?** (You can also link to an open issue here)
To send the parameter `porcentaje` doesn't appear the column related to the percentages of cases by age or sex in the results of the functions:
`agrupar_edad`, `agrupar_edad_sex` and `agrupar_rango_edad_casos`. The issue related is: #127.

* **What is the new behavior (if this is a feature change)?**
The parameter `porcentaje` has been added, calculated and included in the response of the functions: `agrupar_edad`, `agrupar_edad_sex` and `agrupar_rango_edad_casos` . Now in these functions appear the percentages of cases by age or sex

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, it does.
