### PR TITLE
Fix error msg geo 230

### DIFF
--- a/R/checking_data.R
+++ b/R/checking_data.R
@@ -27,7 +27,7 @@ geo_filtro <- function(data_event, dpto = NULL, mpio = NULL) {
   data_dept_filt <- data.frame()
   dept_data <- data.frame()
   cols_ocurren <- NULL
-  msj_error <- "No hay información disponible para el "
+  msj_error <- "No hay informacion disponible para el "
   if (!is.null(dpto)) {
     dept_data <- obtener_info_depts(dpto, mpio)
     stopifnot(
@@ -44,7 +44,8 @@ geo_filtro <- function(data_event, dpto = NULL, mpio = NULL) {
       )
     if (nrow(data_dept_filt) < 1) {
       msj_error <- paste0(msj_error, "departamento: ", dpto)
-      stop("\033[31m", msj_error, "\033[0m", call. = FALSE)
+      stop("\033[31m", msj_error, "departamento: ", dpto, "\033[0m",
+           call. = FALSE)
     }
   }
   if (!is.null(mpio)) {
@@ -61,8 +62,8 @@ geo_filtro <- function(data_event, dpto = NULL, mpio = NULL) {
           as.character(dept_data$codigo_municipio)
       )
     if (nrow(data_dept_filt) < 1) {
-      msj_error <- paste0(msj_error, "municipio: ", mpio)
-      stop("\033[31m", msj_error, "\033[0m", , call. = FALSE)
+      stop("\033[31m", msj_error, "municipio: ", mpio, "\033[0m",
+           call. = FALSE)
     }
   }
   return(data_dept_filt)

--- a/R/checking_data.R
+++ b/R/checking_data.R
@@ -9,6 +9,10 @@
 #' es `NULL`.
 #' @return Un `data.frame` con los datos filtrados con la enfermedad,
 #' departamentos y municipios seleccionados.
+#' @details
+#' Para ver la lista de valores aceptados para los parámetros `dpto` y `mpio`,
+#' ejecuta la función [`import_geo_cods()`]. Se recomienda consultar esta
+#' lista para evitar errores por nombres no válidos.
 #' @examples
 #' data(dengue2020)
 #' data_limpia <- limpiar_data_sivigila(data_event = dengue2020)
@@ -18,9 +22,6 @@
 #' geo_filtro(data_event = data_limpia, dpto = "05", mpio = "05001")
 #' geo_filtro(data_event = data_limpia, dpto = 05, mpio = 05001)
 #' geo_filtro(data_event = data_limpia, dpto = 05, mpio = 001)
-#' \donttest{
-#' geo_filtro(data_event = data_limpia, dpto = "bogota dc", mpio = "bogota dc")
-#' }
 #' @export
 geo_filtro <- function(data_event, dpto = NULL, mpio = NULL) {
   validar_data_event(data_event)

--- a/R/checking_data.R
+++ b/R/checking_data.R
@@ -25,6 +25,7 @@ geo_filtro <- function(data_event, dpto = NULL, mpio = NULL) {
   data_dept_filt <- data.frame()
   dept_data <- data.frame()
   cols_ocurren <- NULL
+  msj_error <- "No hay información disponible para el "
   if (!is.null(dpto)) {
     dept_data <- obtener_info_depts(dpto, mpio)
     stopifnot(
@@ -39,6 +40,10 @@ geo_filtro <- function(data_event, dpto = NULL, mpio = NULL) {
         data_event,
         data_event[[cols_ocurren[1]]] %in% dept_data$codigo_departamento
       )
+    if (nrow(data_dept_filt) < 1) {
+      msj_error <- paste0(msj_error, "departamento: ", dpto)
+      stop("\033[31m", msj_error, "\033[0m", call. = FALSE)
+    }
   }
   if (!is.null(mpio)) {
     stopifnot(
@@ -53,6 +58,10 @@ geo_filtro <- function(data_event, dpto = NULL, mpio = NULL) {
         data_dept_filt[[cols_ocurren[3]]] %in%
           as.character(dept_data$codigo_municipio)
       )
+    if (nrow(data_dept_filt) < 1) {
+      msj_error <- paste0(msj_error, "municipio: ", mpio)
+      stop("\033[31m", msj_error, "\033[0m", , call. = FALSE)
+    }
   }
   return(data_dept_filt)
 }

--- a/R/checking_data.R
+++ b/R/checking_data.R
@@ -44,7 +44,7 @@ geo_filtro <- function(data_event, dpto = NULL, mpio = NULL) {
         data_event[[cols_ocurren[1]]] %in% dept_data$codigo_departamento
       )
     if (nrow(data_dept_filt) < 1) {
-      warning(msj_error, "departamento: ", dpto)
+      warning(msj_error, "departamento: ", dpto, call. = FALSE)
     }
   }
   if (!is.null(mpio)) {
@@ -61,7 +61,7 @@ geo_filtro <- function(data_event, dpto = NULL, mpio = NULL) {
           as.character(dept_data$codigo_municipio)
       )
     if (nrow(data_dept_filt) < 1) {
-      warning(msj_error, "municipio: ", mpio)
+      warning(msj_error, "municipio: ", mpio, call. = FALSE)
     }
   }
   return(data_dept_filt)

--- a/R/checking_data.R
+++ b/R/checking_data.R
@@ -44,9 +44,7 @@ geo_filtro <- function(data_event, dpto = NULL, mpio = NULL) {
         data_event[[cols_ocurren[1]]] %in% dept_data$codigo_departamento
       )
     if (nrow(data_dept_filt) < 1) {
-      msj_error <- paste0(msj_error, "departamento: ", dpto)
-      stop("\033[31m", msj_error, "departamento: ", dpto, "\033[0m",
-           call. = FALSE)
+      warning(msj_error, "departamento: ", dpto)
     }
   }
   if (!is.null(mpio)) {
@@ -63,8 +61,7 @@ geo_filtro <- function(data_event, dpto = NULL, mpio = NULL) {
           as.character(dept_data$codigo_municipio)
       )
     if (nrow(data_dept_filt) < 1) {
-      stop("\033[31m", msj_error, "municipio: ", mpio, "\033[0m",
-           call. = FALSE)
+      warning(msj_error, "municipio: ", mpio)
     }
   }
   return(data_dept_filt)

--- a/R/checking_data.R
+++ b/R/checking_data.R
@@ -18,7 +18,9 @@
 #' geo_filtro(data_event = data_limpia, dpto = "05", mpio = "05001")
 #' geo_filtro(data_event = data_limpia, dpto = 05, mpio = 05001)
 #' geo_filtro(data_event = data_limpia, dpto = 05, mpio = 001)
+#' \donttest{
 #' geo_filtro(data_event = data_limpia, dpto = "bogota dc", mpio = "bogota dc")
+#' }
 #' @export
 geo_filtro <- function(data_event, dpto = NULL, mpio = NULL) {
   validar_data_event(data_event)

--- a/inst/rmarkdown/templates/reports/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/reports/skeleton/skeleton.Rmd
@@ -280,21 +280,29 @@ data_limpia <- limpiar_data_sivigila(data_event)
 ```{r filtrar-data, include = FALSE}
 data_event_filtrada <- data_limpia
 if (params$departamento != "") {
-data_event_filtrada <- geo_filtro(data_event = data_limpia,
-                                  dpto = params$departamento)
-text_init_geo <- paste0(", en el departamento del ",
-                        params$departamento)
+  withCallingHandlers({
+    data_event_filtrada <- geo_filtro(data_event = data_limpia,
+                                      dpto = params$departamento)
+  }, warning = function(w) {
+    stop("\033[31m", conditionMessage(w), "\033[0m", call. = FALSE)
+  })
+  text_init_geo <- paste0(", en el departamento del ",
+                          params$departamento)
   if (params$municipio != "") {
+    withCallingHandlers({
+    data_event_filtrada <- geo_filtro(data_event = data_event_filtrada,
+                                      dpto = params$departamento,
+                                      mpio = params$municipio)
+    }, warning = function(w) {
+      stop("\033[31m", conditionMessage(w), "\033[0m", call. = FALSE)
+    })
     text_init_geo <- paste0(", en el municipio del ",
                             params$municipio)
-    data_event_filtrada <- geo_filtro(data_event = data_event_filtrada,
-                                  dpto = params$departamento,
-                                  mpio = params$municipio)
   }
-text_intro_geo <- paste0(text_init_geo,
-                         " se reportaron ",
-                         nrow(data_event_filtrada),
-                         " casos.")
+  text_intro_geo <- paste0(text_init_geo,
+                           " se reportaron ",
+                           nrow(data_event_filtrada),
+                           " casos.")
 }
 ```
 

--- a/man/geo_filtro.Rd
+++ b/man/geo_filtro.Rd
@@ -33,5 +33,7 @@ geo_filtro(data_event = data_limpia, dpto = "05")
 geo_filtro(data_event = data_limpia, dpto = "05", mpio = "05001")
 geo_filtro(data_event = data_limpia, dpto = 05, mpio = 05001)
 geo_filtro(data_event = data_limpia, dpto = 05, mpio = 001)
+\donttest{
 geo_filtro(data_event = data_limpia, dpto = "bogota dc", mpio = "bogota dc")
+}
 }

--- a/man/geo_filtro.Rd
+++ b/man/geo_filtro.Rd
@@ -24,6 +24,11 @@ departamentos y municipios seleccionados.
 Función que filtra los datos de una enfermedad o evento por
 departamentos y municipios.
 }
+\details{
+Para ver la lista de valores aceptados para los parámetros `dpto` y `mpio`,
+ejecuta la función [`import_geo_cods()`]. Se recomienda consultar esta
+lista para evitar errores por nombres no válidos.
+}
 \examples{
 data(dengue2020)
 data_limpia <- limpiar_data_sivigila(data_event = dengue2020)
@@ -33,7 +38,4 @@ geo_filtro(data_event = data_limpia, dpto = "05")
 geo_filtro(data_event = data_limpia, dpto = "05", mpio = "05001")
 geo_filtro(data_event = data_limpia, dpto = 05, mpio = 05001)
 geo_filtro(data_event = data_limpia, dpto = 05, mpio = 001)
-\donttest{
-geo_filtro(data_event = data_limpia, dpto = "bogota dc", mpio = "bogota dc")
-}
 }


### PR DESCRIPTION
This pull request contains:

- Add warnings in `geo_filtro`: Notify users when no disease data is available for selected departments (`dpto`) or municipalities (`mpio`).
- Improve documentation: Reference `import_geo_codes `as a guideline for valid geographic names.
- Handle validation warnings as errors in template skeleton: Display validation issues related to `dpto` and `mpio `more explicitly, preventing silent failures.